### PR TITLE
Update pytest submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/pytest"]
 	path = tests/pytest
-	url = git@github.com:pytest-dev/pytest.git
+	url = https://github.com/pytest-dev/pytest.git


### PR DESCRIPTION
## Summary
- point `.gitmodules` to `https://github.com/pytest-dev/pytest.git`

## Testing
- `pytest` *(fails: command not found)*